### PR TITLE
Fpad 2488: correct event order in SETS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# fraud-npm
-Repo to hold npm packages used over multi repos
+# Fraud NPM
+
+This repository contains packages that are designed to be reusable across multiple other repositories. 
+Currently, it contains packages for logging and handling fraud events.
+
+## Packages
+
+### 1. Events Package
+
+The events package contains services that validate, construct and reformat SETs. A SET is a fraud signal in the standard
+One Login format, which is an extension of the OpenID shared signals format. The One Login format for SETs is defined 
+here: https://github.com/govuk-one-login/architecture/blob/main/rfc/0052-shared-signals-data-spec.md
+
+The Events package offers the following services:
+
+- __map service__. This returns the Event class that matches a given URI or event type;
+- __populated-set service__. This returns a populated subject event given an event type. 
+- __reformat service__. This maps an inbound event to the TxMA message schema and validates required fields. The format 
+of TxMA messages is defined here: 
+https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/3650519041/Inbound+Event+Field+Mapping+to+TXMA+Audit+Structure;
+- __validate service__. This validates a given SET against a given JSON schema.
+
+### 2. Logging Package
+
+The Logging package extends the Logging package in Powertools for AWS Lambda. The package allows messages to be logged 
+at debug, info, warning, error, critical levels, and also allows metrics to be logged. Metrics are logged in Amazon 
+CloudWatch Embedded Metric Format (EMF).
+
+### 3. Development Environment Set Up
+
+Setup your environment using the following tools:
+
+- VS Code - [Install VS Code](https://code.visualstudio.com/download)
+- Node.js - [Install Node.js](https://nodejs.org/en/), including `npm`.
+
+### 4. Local Development
+
+Install `npm` dependencies:
+
+```bash
+npm i
+```
+### 5. Adding a new package
+
+To add a new package, do the following:
+
+- add the new package to the top-level of the fraud-npm project;
+- add the new package to the publish.yaml workflow action. This action allows the user to choose from a drop-down of 
+packages to publish;
+- go to the fraud-npm repo in GitLab, choose your new package from the packages list in the bottom-right of the screen,
+then choose Package Settings from the bottom-right, and then add all the repositories you would like to be able to
+access your new package to the list in the "Manage Actions access" section.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To add a new package, do the following:
 - add the new package to the top-level of the fraud-npm project;
 - add the new package to the publish.yaml workflow action. This action allows the user to choose from a drop-down of 
 packages to publish;
-- go to the fraud-npm repo in GitLab, choose your new package from the packages list in the bottom-right of the screen,
+- go to the fraud-npm repo in GitHub, choose your new package from the packages list in the bottom-right of the screen,
 then choose Package Settings from the bottom-right, and then add all the repositories you would like to be able to
 access your new package to the list in the "Manage Actions access" section.

--- a/events/event-mapping/activity-maps.ts
+++ b/events/event-mapping/activity-maps.ts
@@ -20,8 +20,6 @@ async function generateActivityUserSessionEvents(eventType: ActivityEventTypes, 
         startTimeInMillis, endTimeInMillis)
 
   return {
-    ...metadataAndDetails,
-
     [AllEventURIs[eventType].uri]: {
       subject: {
         format: 'uri',
@@ -31,7 +29,8 @@ async function generateActivityUserSessionEvents(eventType: ActivityEventTypes, 
         format : "opaque",
         id: sessionId
       },
-    }
+    },
+    ...metadataAndDetails
   }
 }
 

--- a/events/event-mapping/caep-maps.ts
+++ b/events/event-mapping/caep-maps.ts
@@ -49,8 +49,6 @@ async function generateCaepDeviceSubjectEvents(eventType: CaepEventTypes, device
       startTimeInMillis, endTimeInMillis)
 
   return {
-    ...metadataAndDetails,
-
     [AllEventURIs[eventType].uri]: {
       subject: {
         device: {
@@ -63,7 +61,8 @@ async function generateCaepDeviceSubjectEvents(eventType: CaepEventTypes, device
           id: tenantId
         }
       }
-    }
+    },
+    ...metadataAndDetails
   }
 }
 
@@ -76,8 +75,6 @@ async function generateCaepSessionSubjectEvents(eventType: CaepEventTypes, sessi
     startTimeInMillis, endTimeInMillis)
 
   return {
-    ...metadataAndDetails,
-
     [AllEventURIs[eventType].uri]: {
       subject: {
         session: {
@@ -95,6 +92,7 @@ async function generateCaepSessionSubjectEvents(eventType: CaepEventTypes, sessi
         }
       }
     },
+    ...metadataAndDetails
   }
 }
 
@@ -105,14 +103,14 @@ async function generateCaepTokenSubjectEvents(eventType: CaepEventTypes, tokenFo
     startTimeInMillis, endTimeInMillis)
 
   return {
-    ...metadataAndDetails,
     [AllEventURIs[eventType].uri]: {
       subject: {
         format: tokenFormat,
         iss: tokenIssuer,
         jti: jti
       }
-    }
+    },
+    ...metadataAndDetails
   }
 }
 

--- a/events/event-mapping/events-mapping.ts
+++ b/events/event-mapping/events-mapping.ts
@@ -104,13 +104,13 @@ export async function generateStandardUserSubjectEvents(eventType: AllEventTypes
     timestampType, startTimeInMillis, endTimeInMillis)
 
   return {
-    ...metadataAndDetails,
     [AllEventURIs[eventType].uri]: {
       subject: {
         format: "uri",
         uri: id
       },
-    }
+    },
+    ...metadataAndDetails
   }
 }
 

--- a/events/event-mapping/notification-maps.test.ts
+++ b/events/event-mapping/notification-maps.test.ts
@@ -36,7 +36,7 @@ describe('populated notification events', () => {
 
       const set: SETEvents = await subjectFn(DEFAULT_URI, 1000, 2000, ...extraArgs);
 
-      await validateSetEvents(set, type, schema, true);
+      await validateSetEvents(set, type, schema);
     }
   });
 });

--- a/events/event-mapping/notification-maps.ts
+++ b/events/event-mapping/notification-maps.ts
@@ -46,8 +46,6 @@ async function generateNotificationDeviceSubjectEvents(eventType: NotificationEv
   let metadataAndDetails = await generateMetaDataAndDetailsEvents(eventType, timestampType, startTimeInMillis, endTimeInMillis);
 
   return {
-    ...metadataAndDetails,
-
     [AllEventURIs[eventType].uri]: {
       subject: {
         device: {
@@ -56,6 +54,7 @@ async function generateNotificationDeviceSubjectEvents(eventType: NotificationEv
         },
       },
     },
+    ...metadataAndDetails
   };
 }
 

--- a/events/event-mapping/risc-maps.ts
+++ b/events/event-mapping/risc-maps.ts
@@ -51,13 +51,13 @@ async function generateRiscEmailSubjectEvents(eventType: RiscEventTypes, email: 
   let metadataAndDetails = await generateMetaDataAndDetailsEvents(eventType, timestampType, startTimeInMillis, endTimeInMillis)
 
   return {
-    ...metadataAndDetails,
     [AllEventURIs[eventType].uri]: {
       subject: {
         format: 'email',
         email: email
       }
-    }
+    },
+    ...metadataAndDetails
   }
 }
 
@@ -68,13 +68,13 @@ async function generateRiscPhoneSubjectEvents(eventType: RiscEventTypes, phoneNu
   let metadataAndDetails = await generateMetaDataAndDetailsEvents(eventType, timestampType, startTime, endTime)
 
   return {
-    ...metadataAndDetails,
     [AllEventURIs[eventType].uri]: {
       subject: {
         format: 'phone',
         phone: phoneNumber
-      },
-    }
+      }
+    },
+    ...metadataAndDetails,
   }
 }
 

--- a/events/package.json
+++ b/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/events",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Fraud common events",
   "author": {
     "name": "FPAD"

--- a/events/services/populated-set/populated-set.test.ts
+++ b/events/services/populated-set/populated-set.test.ts
@@ -64,6 +64,34 @@ describe('PopulatedSetService', () => {
       await validateSetEvents(set, RiscEventTypes.AccountDisabled, accountDisabledSchema, true);
     });
 
+    it('should retrieve correct SET by URI with timeStamp of now and all defaults', async () => {
+
+      jest.useFakeTimers().setSystemTime(10000);
+      const uri = 'uri:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw='
+
+      const set = await PopulatedSetService.getPopulatedSetNow(RiscEventURIs[RiscEventTypes.AccountDisabled].uri,
+        uri)
+
+      const expectedSet: SETEvents =
+        {
+          'https://vocab.account.gov.uk/secevent/v1/eventMetadata': { event_timestamp_ms: 10000 },
+          'https://vocab.account.gov.uk/secevent/v1/accountDisabled/eventDetails': { location: 'GB' },
+          'https://schemas.openid.net/secevent/risc/event-type/account-disabled': {
+            subject: {
+              format: 'uri',
+              uri: uri
+            },
+            reason: 'User suspected of fraud'
+          }
+        }
+
+      expect(set).toEqual(expectedSet);
+
+      await validateSetEvents(set, RiscEventTypes.AccountDisabled, accountDisabledSchema, true);
+    });
+
+
+
   });
 
 });


### PR DESCRIPTION
This change ensures that the "events" in the events block of a SET are in the correct order, i.e. subject -> metadata -> details. Previously the ordering was metadata -> details -> subject which, although technically not a problem, is confusing when SETs are output to the console.

I have also added material to the README.md file, and added an extra unit test.