### PR TITLE
SET-1388 - Inbound | Group ID: Onboard new signal subjectGroup

### DIFF
--- a/events/enums/event-names.ts
+++ b/events/enums/event-names.ts
@@ -23,5 +23,6 @@ export enum TxmaEventNames {
   AccountConcern = 'SSF_INBOUND_ACCOUNT_CONCERN',
   AccountBlock = 'SSF_INBOUND_ACCOUNT_BLOCK',
   DeviceConcern = 'SSF_INBOUND_DEVICE_CONCERN',
+  SubjectGroup = 'SSF_INBOUND_SUBJECT_GROUP',
   Verification = 'SSF_INBOUND_VERIFICATION',
 }

--- a/events/enums/notification-events.ts
+++ b/events/enums/notification-events.ts
@@ -5,6 +5,7 @@ export enum NotificationEventTypes {
   AccountBlock = 'accountBlock',
   DeviceConcern = 'deviceConcern',
   CredentialConcern = 'credentialConcern',
+  SubjectGroup = 'subjectGroup',
 }
 
 export const NotificationEventKeys: Array<NotificationEventTypes> = Object.keys(
@@ -30,5 +31,9 @@ export const NotificationEventURIs: Record<NotificationEventTypes, UriInfo> = {
   [NotificationEventTypes.CredentialConcern]: {
     uri: GOV_UK_SCHEMA_ROOT_NOTIFICATION + 'credentialConcern',
     detailsKey: 'credentialConcern',
+  },
+  [NotificationEventTypes.SubjectGroup]: {
+    uri: GOV_UK_SCHEMA_ROOT_NOTIFICATION + 'subjectGroup',
+    detailsKey: 'subjectGroup',
   },
 };

--- a/events/event-classes/notification/subject-group.ts
+++ b/events/event-classes/notification/subject-group.ts
@@ -1,0 +1,16 @@
+import { BaseEvent } from '../base-event';
+import { SsfSchema } from '../../types/ssf';
+import { NotificationEventTypes } from '../../enums/notification-events';
+import { TxmaEventNames } from '../../enums/event-names';
+import * as eventSchema from '../../schemas/notification/subject-group.json';
+
+export class SubjectGroupEvent extends BaseEvent {
+  constructor(message?: SsfSchema) {
+    super(
+      NotificationEventTypes.SubjectGroup,
+      TxmaEventNames.SubjectGroup,
+      eventSchema,
+      message
+    );
+  }
+}

--- a/events/event-mapping/notification-maps.test.ts
+++ b/events/event-mapping/notification-maps.test.ts
@@ -2,6 +2,7 @@ import * as accountConcernSchema from '../schemas/notification/account-concern.j
 import * as accountBlockSchema from '../schemas/notification/account-block.json';
 import * as deviceConcernSchema from '../schemas/notification/device-concern.json';
 import * as credentialConcernSchema from '../schemas/notification/credential-concern.json';
+import * as subjectGroupSchema from '../schemas/notification/subject-group.json';
 import {
   NotificationEventTypes,
   NotificationEventURIs,
@@ -32,6 +33,11 @@ const notificationTestCases: TestInfo[] = [
     type: NotificationEventTypes.CredentialConcern,
     schema: credentialConcernSchema,
     extraArgs: ['admin', 'reason-admin'],
+  },
+  {
+    type: NotificationEventTypes.SubjectGroup,
+    schema: subjectGroupSchema,
+    extraArgs: [],
   },
 ];
 

--- a/events/event-mapping/notification-maps.ts
+++ b/events/event-mapping/notification-maps.ts
@@ -15,6 +15,7 @@ import {
 } from './events-mapping';
 import { AccountBlockEvent } from '../event-classes/notification/account-block';
 import { CredentialConcernEvent } from '../event-classes/notification/credential-concern';
+import { SubjectGroupEvent } from '../event-classes/notification/subject-group';
 
 export const notificationEventsMapping: Record<string, any> = {
   [NotificationEventURIs[NotificationEventTypes.AccountConcern].uri]:
@@ -25,6 +26,8 @@ export const notificationEventsMapping: Record<string, any> = {
     DeviceConcernEvent,
   [NotificationEventURIs[NotificationEventTypes.CredentialConcern].uri]:
     CredentialConcernEvent,
+  [NotificationEventURIs[NotificationEventTypes.SubjectGroup].uri]:
+    SubjectGroupEvent,
 };
 
 export function addStandardNotificationFields(
@@ -205,5 +208,19 @@ export const notificationPopulatedEventsMapping: Record<
     );
 
     return events;
+  },
+
+  [NotificationEventURIs[NotificationEventTypes.SubjectGroup].uri]: async (
+    id: string,
+    startTimeInMillis: number,
+    endTimeInMillis: number
+  ) => {
+    return await generateStandardUserSubjectEvents(
+      NotificationEventTypes.SubjectGroup,
+      id,
+      TimestampTypes.timeStamp,
+      startTimeInMillis,
+      endTimeInMillis
+    );
   },
 };

--- a/events/package-lock.json
+++ b/events/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/events",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/events",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "ajv": "^8.18.0",
         "ajv-formats": "^2.1.1",

--- a/events/package-lock.json
+++ b/events/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/events",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/events",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "ajv": "^8.18.0",
         "ajv-formats": "^2.1.1",

--- a/events/package.json
+++ b/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/events",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Fraud common events",
   "author": {
     "name": "FPAD"

--- a/events/schemas/notification/subject-group.json
+++ b/events/schemas/notification/subject-group.json
@@ -1,0 +1,24 @@
+{
+  "properties": {
+    "subject": {
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "format",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "event_timestamp": {
+      "type": "number"
+    }
+  },
+  "required": ["subject"],
+  "type": "object"
+}


### PR DESCRIPTION
## Tickets solved

What tickets will be solved (marked as done) once this PR is merged?

- [SET-1388](https://govukverify.atlassian.net/browse/SET-1388)

## Description 

Adds support for the subjectGroup inbound signal type to the events package.

## Changes Made

- added SubjectGroup = 'SSF_INBOUND_SUBJECT_GROUP' to TxmaEventNames
- added SubjectGroup to NotificationEventTypes and its URI mapping
- new event class wiring up the type, TxMA name and schema
- new schema requiring subject with format and uri
- registered SubjectGroupEvent in both notificationEventsMapping and notificationPopulatedEventsMapping
- added SubjectGroup test case

Tests: 

<img width="1606" height="356" alt="image" src="https://github.com/user-attachments/assets/052d3705-3baf-4834-ad8e-ab0daa111471" />

<img width="1592" height="418" alt="image" src="https://github.com/user-attachments/assets/5f106e60-0c2d-4c16-8fb5-7d7eaf06e560" />


[SET-1388]: https://govukverify.atlassian.net/browse/SET-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ